### PR TITLE
Multi: abort: doesn't run req aborted before they even ran

### DIFF
--- a/src/FetchyMulti.tsx
+++ b/src/FetchyMulti.tsx
@@ -59,7 +59,7 @@ export class FetchyMulti extends React.Component<
 
   private mounted: boolean = true;
 
-  public async componentDidMount() {
+  public componentDidMount() {
     this.checkQueue();
   }
 
@@ -266,6 +266,7 @@ export class FetchyMulti extends React.Component<
       if (runningRequest) {
         return false;
       }
+
       return true;
     });
 

--- a/src/FetchyMulti.tsx
+++ b/src/FetchyMulti.tsx
@@ -255,6 +255,11 @@ export class FetchyMulti extends React.Component<
     const availableCount = concurrency - runningRequestCount;
     const requestsTodo = this.props.requests.filter(req => {
       const runningRequest = this.superAgentRequests[req.id];
+
+      if (this.state[req.id]) {
+        return false;
+      }
+
       if (runningRequest) {
         return false;
       }

--- a/test/FetchyMulti.spec.tsx
+++ b/test/FetchyMulti.spec.tsx
@@ -131,7 +131,6 @@ describe("FetchyMulti", () => {
     );
 
     res.bag.retry("1");
-    res.wrapper.update();
     expect(res.bag.states["1"].pending).toEqual(true);
   });
   it("abort on update", async () => {
@@ -166,5 +165,34 @@ describe("FetchyMulti", () => {
     expect(res.bag.states["1"]).toBeUndefined();
     expect(res.bag.states["2"].pending).toEqual(true);
     expect(res.bag.states["3"].pending).toEqual(true);
+  });
+  it("abort not started requests", async () => {
+    const res = setup(FetchyMulti, {
+      requests: [
+        {
+          id: "1",
+          url: `${base}/200`,
+        },
+        {
+          id: "2",
+          url: `${base}/200`,
+        },
+        {
+          id: "3",
+          url: `${base}/200?delay=100`,
+        },
+      ],
+    });
+    expect(res.bag.states["1"].pending).toEqual(true);
+    expect(res.bag.states["2"].pending).toEqual(true);
+
+    res.bag.abort("3");
+
+    await waitUntil(() => !res.bag.states["1"].pending);
+    await waitUntil(() => !res.bag.states["2"].pending);
+
+    expect(res.bag.states["3"].pending).toEqual(false);
+    expect(res.bag.states["3"].rejected).toEqual(true);
+    expect(res.bag.states["3"].error).not.toBeUndefined()
   });
 });


### PR DESCRIPTION
If abort before fetch began, req is `rejected` but is collected anyway to be run because they are not yet in `runningRequest`
We need to check if a state already exist for a new req to be considered `requestsTodo`